### PR TITLE
Contrib Fake PR: Fix Bug#91737: Please log GTID_EXECUTED when running RESET MASTER.

### DIFF
--- a/sql/rpl_source.cc
+++ b/sql/rpl_source.cc
@@ -1198,6 +1198,7 @@ void kill_zombie_dump_threads(THD *thd) {
 */
 bool reset_binary_logs_and_gtids(THD *thd, bool unlock_global_read_lock) {
   bool ret = false;
+  char *previous_gtid_executed = nullptr, *current_gtid_executed = nullptr;
 
   /*
     RESET BINARY LOGS AND GTIDS command should ignore 'read-only' and
@@ -1220,6 +1221,8 @@ bool reset_binary_logs_and_gtids(THD *thd, bool unlock_global_read_lock) {
     goto end;
   }
 
+  gtid_state->get_executed_gtids()->to_string(&previous_gtid_executed);
+
   if (mysql_bin_log.is_open()) {
     /*
       mysql_bin_log.reset_logs will delete the binary logs *and* clear
@@ -1238,6 +1241,14 @@ bool reset_binary_logs_and_gtids(THD *thd, bool unlock_global_read_lock) {
     ret = (gtid_state->clear(thd) != 0);
     global_tsid_lock->unlock();
   }
+
+  gtid_state->get_executed_gtids()->to_string(&current_gtid_executed);
+
+  LogErr(SYSTEM_LEVEL, ER_GTID_EXECUTED_WAS_UPDATED, previous_gtid_executed,
+         current_gtid_executed);
+
+  my_free(current_gtid_executed);
+  my_free(previous_gtid_executed);
 
 end:
   /*


### PR DESCRIPTION
This is a "Contrib Fake PR".  It is there so people can comment on this work in case it needs adjustments.  This has been contributed on 2024-05-09 as a patch file in [Bug#91737: Please log GTID_EXECUTED when running RESET MASTER](https://bugs.mysql.com/bug.php?id=91737).

Historical note: `RESET MASTER` is the old command name for `RESET BINARY LOGS AND GTIDS`.

This PR merges on 8.3.0, and the patch file also applies on 8.4.0.  It does not apply on 8.0.37, but it should not be too hard to adapt, let me know if this is needed.

Ideally, in addition to being included in a next Innovation Release, this would be back-ported in 8.4 and 8.0.  Some might consider this a breaking change as it modifies logging, but others might consider this a "small enough" change with enough value to be back-ported.  In case a change in logging is show-stopper for a back-port, this change could be put behind a "disabled by default" feature-flag / global variable (let me know if you need an updated patch for this).

This work is inspired by the way `GTID_PURGED` and `GTID_EXECUTED` are logged when changing `GTID_PURGED`:
- https://github.com/jfg956/mysql-server/blob/mysql-8.3.0/sql/sys_vars.cc#L6547 (function `Sys_var_gtid_purged::global_update` in file `sql/sys_vars.cc`)

Tests in [1st PR comment](https://github.com/jfg956/mysql-server/pull/5#issuecomment-2018865402).

There is a limit to this implementation, inherited from the way `GTID_PURGED` and `GTID_EXECUTED` are logged when changing `GTID_PURGED`.  When `GTID_EXECUTED` is long (200+ UUIDs), the log is truncated (the same way logs are truncated with 100+ UUIDs when changing `GTID_PURGED`).  See [2nd PR comment](https://github.com/jfg956/mysql-server/pull/5#issuecomment-2018865903) for details of this limit.

More JFG development notes:
- Work branch: https://github.com/jfg956/mysql-server/tree/mysql-8.3.0_bug91737/
- Brain dump: https://github.com/jfg956/mysql-server/blob/mysql-8.3.0_bug91737/jfg_brain_dump.md