### PR TITLE
RFC Fake PR: MySQL 8.4.0 - Bug#106645: Slow query log is not logging database/schema name.

### DIFF
--- a/mysql-test/include/slow_query_log_file_reset.inc
+++ b/mysql-test/include/slow_query_log_file_reset.inc
@@ -1,0 +1,8 @@
+
+let $_INTERNAL_MYSQLD_DATADIR = `select @@datadir`;
+let $_INTERNAL_MYSQLD_SLOW_QUERY_LOG_FILE = `select @@slow_query_log_file`;
+
+--echo
+--echo ## Resetting the slow query log file.
+--remove_file $MYSQLD_DATADIR/$_INTERNAL_MYSQLD_SLOW_QUERY_LOG_FILE
+FLUSH SLOW LOGS;

--- a/mysql-test/suite/sys_vars/r/log_slow_extra_db_basic.result
+++ b/mysql-test/suite/sys_vars/r/log_slow_extra_db_basic.result
@@ -1,0 +1,87 @@
+# Bug#106645: Slow query log is not logging database/schema name.
+
+# test global variable "log_slow_extra_db"
+
+SELECT @@global.log_slow_extra_db INTO @old_lsed;
+SELECT @@global.log_output        INTO @old_lo;
+SELECT @@global.slow_query_log    INTO @old_sql;
+# invalid values / types
+SET GLOBAL log_slow_extra_db=symbol;
+ERROR 42000: Variable 'log_slow_extra_db' can't be set to the value of 'symbol'
+SET GLOBAL log_slow_extra_db="string";
+ERROR 42000: Variable 'log_slow_extra_db' can't be set to the value of 'string'
+SET GLOBAL log_slow_extra_db=99;
+ERROR 42000: Variable 'log_slow_extra_db' can't be set to the value of '99'
+SET GLOBAL log_slow_extra_db=0.5;
+ERROR 42000: Incorrect argument type to variable 'log_slow_extra_db'
+
+# only GLOBAL scope is valid
+SET SESSION log_slow_extra_db=0;
+ERROR HY000: Variable 'log_slow_extra_db' is a GLOBAL variable and should be set with SET GLOBAL
+
+# valid values
+SET GLOBAL slow_query_log=0;
+SET GLOBAL log_slow_extra_db=0;
+SELECT @@global.log_slow_extra_db;
+@@global.log_slow_extra_db
+0
+SET GLOBAL log_slow_extra_db=1;
+SELECT @@global.log_slow_extra_db;
+@@global.log_slow_extra_db
+1
+SET GLOBAL log_slow_extra_db=OFF;
+SELECT @@global.log_slow_extra_db;
+@@global.log_slow_extra_db
+0
+SET GLOBAL log_slow_extra_db=ON;
+SELECT @@global.log_slow_extra_db;
+@@global.log_slow_extra_db
+1
+SET GLOBAL log_slow_extra_db=DEFAULT;
+SELECT @@global.log_slow_extra_db;
+@@global.log_slow_extra_db
+1
+
+# warnings and errors
+SET GLOBAL slow_query_log=1;
+
+# Switching slow query log file format while target is not FILE is legal,
+# but does nothing. Throw a warning!
+SET GLOBAL log_output="TABLE";
+SELECT @@global.log_slow_extra_db INTO @old;
+SET GLOBAL log_slow_extra_db=0;
+Warnings:
+Warning	3795	slow query log file format changed as requested, but setting will have no effect when not actually logging to a file.
+# Value must have changed:
+SELECT @@global.log_slow_extra_db!=@old;
+@@global.log_slow_extra_db!=@old
+1
+SET GLOBAL log_slow_extra_db=DEFAULT;
+Warnings:
+Warning	3795	slow query log file format changed as requested, but setting will have no effect when not actually logging to a file.
+
+# Switching slow query log file format while target is not FILE is legal,
+# but does nothing. Throw a warning!
+SET GLOBAL log_output="NONE";
+SELECT @@global.log_slow_extra_db INTO @old;
+SET GLOBAL log_slow_extra_db=0;
+Warnings:
+Warning	3795	slow query log file format changed as requested, but setting will have no effect when not actually logging to a file.
+# Value must have changed:
+SELECT @@global.log_slow_extra_db!=@old;
+@@global.log_slow_extra_db!=@old
+1
+SET GLOBAL log_slow_extra_db=DEFAULT;
+Warnings:
+Warning	3795	slow query log file format changed as requested, but setting will have no effect when not actually logging to a file.
+
+# clean up
+SET GLOBAL log_slow_extra_db=@old_lsed;
+Warnings:
+Warning	3795	slow query log file format changed as requested, but setting will have no effect when not actually logging to a file.
+SET GLOBAL log_output=@old_lo;
+SET GLOBAL slow_query_log=@old_sql;
+TRUNCATE TABLE mysql.general_log;
+TRUNCATE TABLE mysql.slow_log;
+
+# READY

--- a/mysql-test/suite/sys_vars/r/log_slow_extra_db_func.result
+++ b/mysql-test/suite/sys_vars/r/log_slow_extra_db_func.result
@@ -30,6 +30,19 @@ SELECT sleep(0.5);
 ## Resetting the slow query log file.
 FLUSH SLOW LOGS;
 
+SET @@session.long_query_time = 0.1;
+SELECT sleep(0.5);
+sleep(0.5)
+0
+
+# Time: x
+# UH: n Id: n Db: 
+# Query_time: n Lock_time: n Rows_sent: 1  Rows_examined: 1
+SELECT sleep(0.5);
+
+## Resetting the slow query log file.
+FLUSH SLOW LOGS;
+
 SET @@global.log_slow_extra_db = 0;
 SELECT sleep(0.5);
 sleep(0.5)

--- a/mysql-test/suite/sys_vars/r/log_slow_extra_db_func.result
+++ b/mysql-test/suite/sys_vars/r/log_slow_extra_db_func.result
@@ -1,0 +1,49 @@
+# Bug#106645: Slow query log is not logging database/schema name.
+
+## Save state.
+SET @global_log_output = @@global.log_output;
+SET @global_slow_query_log = @@global.slow_query_log;
+SET @global_slow_query_log_file = @@global.slow_query_log_file;
+SET @global_log_slow_extra = @@global.log_slow_extra;
+SET @global_log_slow_extra_db = @@global.log_slow_extra_db;
+
+## Common to all tests below.
+SET @@global.slow_query_log_file = 'my_slow_test.log';
+SET @@global.log_output = 'FILE';
+SET @@global.slow_query_log = ON;
+SET @@global.log_slow_extra = 0;
+SET @@session.long_query_time = 0.1;
+
+## Resetting the slow query log file.
+FLUSH SLOW LOGS;
+
+SET @@global.log_slow_extra_db = 1;
+SELECT sleep(0.5);
+sleep(0.5)
+0
+
+# Time: x
+# UH: n Id: n Db: test
+# Query_time: n Lock_time: n Rows_sent: 1  Rows_examined: 1
+SELECT sleep(0.5);
+
+## Resetting the slow query log file.
+FLUSH SLOW LOGS;
+
+SET @@global.log_slow_extra_db = 0;
+SELECT sleep(0.5);
+sleep(0.5)
+0
+
+# Time: x
+# UH: n Id: n
+# Query_time: n Lock_time: n Rows_sent: 1  Rows_examined: 1
+use test;
+SELECT sleep(0.5);
+
+## Restore state.
+SET @@global.log_slow_extra = @global_log_slow_extra;
+SET @@global.log_slow_extra_db = @global_log_slow_extra_db;
+SET @@global.log_output = @global_log_output;
+SET @@global.slow_query_log = @global_slow_query_log;
+SET @@global.slow_query_log_file = @global_slow_query_log_file;

--- a/mysql-test/suite/sys_vars/r/log_slow_extra_func.result
+++ b/mysql-test/suite/sys_vars/r/log_slow_extra_func.result
@@ -1,0 +1,48 @@
+# WL#12393: Logging: Add new command line option for richer slow query logging
+
+## Save state.
+SET @global_log_output = @@global.log_output;
+SET @global_slow_query_log = @@global.slow_query_log;
+SET @global_slow_query_log_file = @@global.slow_query_log_file;
+SET @global_log_slow_extra = @@global.log_slow_extra;
+SET @global_log_slow_extra_db = @@global.log_slow_extra_db;
+
+## Common to all tests below.
+SET @@global.slow_query_log_file = 'my_slow_test.log';
+SET @@global.log_output = 'FILE';
+SET @@global.slow_query_log = ON;
+SET @@global.log_slow_extra_db = 1;
+SET @@session.long_query_time = 0.1;
+
+## Resetting the slow query log file.
+FLUSH SLOW LOGS;
+
+SET @@global.log_slow_extra = 0;
+SELECT sleep(0.5);
+sleep(0.5)
+0
+
+# Time: x
+# User@Host: n Id: n Db: test
+# Query_time: n Lock_time: n Rows_sent: 1  Rows_examined: 1
+SELECT sleep(0.5);
+
+## Resetting the slow query log file.
+FLUSH SLOW LOGS;
+
+SET @@global.log_slow_extra = 1;
+SELECT sleep(0.5);
+sleep(0.5)
+0
+
+# Time: x
+# User@Host: n Id: n Db: test
+# Query_time: n Lock_time: n Rows_sent: 1  Rows_examined: 1 Thread_id: n Errno: 0 Killed: 0 Bytes_received: n Bytes_sent: n Read_first: 0 Read_last: 0 Read_key: 0 Read_next: 0 Read_prev: 0 Read_rnd: 0 Read_rnd_next: 0 Sort_merge_passes: 0 Sort_range_count: 0 Sort_rows: 0 Sort_scan_count: 0 Created_tmp_disk_tables: 0 Created_tmp_tables: 0 Start: n End: n
+SELECT sleep(0.5);
+
+## Restore state.
+SET @@global.log_slow_extra = @global_log_slow_extra;
+SET @@global.log_slow_extra_db = @global_log_slow_extra_db;
+SET @@global.log_output = @global_log_output;
+SET @@global.slow_query_log = @global_slow_query_log;
+SET @@global.slow_query_log_file = @global_slow_query_log_file;

--- a/mysql-test/suite/sys_vars/t/log_slow_extra_db_basic.test
+++ b/mysql-test/suite/sys_vars/t/log_slow_extra_db_basic.test
@@ -1,0 +1,86 @@
+--echo # Bug#106645: Slow query log is not logging database/schema name.
+--echo
+--echo # test global variable "log_slow_extra_db"
+--echo
+
+SELECT @@global.log_slow_extra_db INTO @old_lsed;
+SELECT @@global.log_output        INTO @old_lo;
+SELECT @@global.slow_query_log    INTO @old_sql;
+
+--echo # invalid values / types
+
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL log_slow_extra_db=symbol;
+
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL log_slow_extra_db="string";
+
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL log_slow_extra_db=99;
+
+--error ER_WRONG_TYPE_FOR_VAR
+SET GLOBAL log_slow_extra_db=0.5;
+
+--echo
+--echo # only GLOBAL scope is valid
+
+--error ER_GLOBAL_VARIABLE
+SET SESSION log_slow_extra_db=0;
+
+--echo
+
+--echo # valid values
+SET GLOBAL slow_query_log=0;
+
+SET GLOBAL log_slow_extra_db=0;
+SELECT @@global.log_slow_extra_db;
+
+SET GLOBAL log_slow_extra_db=1;
+SELECT @@global.log_slow_extra_db;
+
+SET GLOBAL log_slow_extra_db=OFF;
+SELECT @@global.log_slow_extra_db;
+
+SET GLOBAL log_slow_extra_db=ON;
+SELECT @@global.log_slow_extra_db;
+
+SET GLOBAL log_slow_extra_db=DEFAULT;
+SELECT @@global.log_slow_extra_db;
+
+--echo
+
+--echo # warnings and errors
+
+SET GLOBAL slow_query_log=1;
+--echo
+
+--echo # Switching slow query log file format while target is not FILE is legal,
+--echo # but does nothing. Throw a warning!
+SET GLOBAL log_output="TABLE";
+SELECT @@global.log_slow_extra_db INTO @old;
+SET GLOBAL log_slow_extra_db=0;
+--echo # Value must have changed:
+SELECT @@global.log_slow_extra_db!=@old;
+SET GLOBAL log_slow_extra_db=DEFAULT;
+--echo
+
+--echo # Switching slow query log file format while target is not FILE is legal,
+--echo # but does nothing. Throw a warning!
+SET GLOBAL log_output="NONE";
+SELECT @@global.log_slow_extra_db INTO @old;
+SET GLOBAL log_slow_extra_db=0;
+--echo # Value must have changed:
+SELECT @@global.log_slow_extra_db!=@old;
+SET GLOBAL log_slow_extra_db=DEFAULT;
+--echo
+
+--echo # clean up
+SET GLOBAL log_slow_extra_db=@old_lsed;
+SET GLOBAL log_output=@old_lo;
+SET GLOBAL slow_query_log=@old_sql;
+TRUNCATE TABLE mysql.general_log;
+TRUNCATE TABLE mysql.slow_log;
+
+--echo
+
+--echo # READY

--- a/mysql-test/suite/sys_vars/t/log_slow_extra_db_func.test
+++ b/mysql-test/suite/sys_vars/t/log_slow_extra_db_func.test
@@ -1,28 +1,9 @@
 --echo # Bug#106645: Slow query log is not logging database/schema name.
 --echo
 
---echo ## Save state.
-SET @global_log_output = @@global.log_output;
-SET @global_slow_query_log = @@global.slow_query_log;
-SET @global_slow_query_log_file = @@global.slow_query_log_file;
-SET @global_log_slow_extra = @@global.log_slow_extra;
-SET @global_log_slow_extra_db = @@global.log_slow_extra_db;
+# Common variables for all tests.
 
---echo
---echo ## Common to all tests below.
-
-let $MYSQLD_DATADIR= `select @@datadir`;
-
-# Setting slow_query_log_file before enabling the slow log to avoid creating a random file.
-SET @@global.slow_query_log_file = 'my_slow_test.log';
-
-SET @@global.log_output = 'FILE';
-SET @@global.slow_query_log = ON;
-
-# This needs to go after log_output as it might warn otherwise.
-SET @@global.log_slow_extra = 0;
-
-SET @@session.long_query_time = 0.1;
+--let $MYSQLD_DATADIR= `select @@datadir`
 
 # These regex patterns are for masking-out non-deterministic output.
 --let $PATTERN_VER= /.*Version.*started with.*\n//
@@ -39,9 +20,31 @@ SET @@session.long_query_time = 0.1;
 
 --let $PATTERN= $PATTERN_VER $PATTERN_TCP $PATTERN_TIME1 $PATTERN_TIME2 $PATTERN_UH1 $PATTERN_UH2 $PATTERN_QT $PATTERN_TS
 
---source include/slow_query_log_file_reset.inc
+--echo ## Save state.
+SET @global_log_output = @@global.log_output;
+SET @global_slow_query_log = @@global.slow_query_log;
+SET @global_slow_query_log_file = @@global.slow_query_log_file;
+SET @global_log_slow_extra = @@global.log_slow_extra;
+SET @global_log_slow_extra_db = @@global.log_slow_extra_db;
+
+--echo
+--echo ## Common to all tests below.
+
+# Setting slow_query_log_file before enabling the slow log to avoid creating a random file.
+SET @@global.slow_query_log_file = 'my_slow_test.log';
+
+SET @@global.log_output = 'FILE';
+SET @@global.slow_query_log = ON;
+
+# This needs to go after log_output as it might warn otherwise.
+SET @@global.log_slow_extra = 0;
+
+SET @@session.long_query_time = 0.1;
 
 # We test log_slow_extra_db = 1 before 0 as we want to make sure a "use ..." appears with 0.
+
+# Clean slow query log file before test.
+--source include/slow_query_log_file_reset.inc
 
 --echo
 SET @@global.log_slow_extra_db = 1;
@@ -52,9 +55,34 @@ SELECT sleep(0.5);
 --replace_regex $PATTERN
 --exec cat $MYSQLD_DATADIR/my_slow_test.log
 
+# New connection with no selected database.
+# Below from the doc...
+# https://dev.mysql.com/doc/dev/mysql-server/latest/PAGE_MYSQL_TEST_COMMANDS.html
+#   connect (name, host_name, user_name, password, db_name [,port_num ... 
+#   *NO-ONE* means that no default database should be selected
+--connect(conn1,localhost,root,,*NO-ONE*)
+connection conn1;
+
+# Clean slow query log file before test.
 --source include/slow_query_log_file_reset.inc
 
+--echo
+SET @@session.long_query_time = 0.1;
+SELECT sleep(0.5);
+
+--echo
+# Checking the content of the slow query log file.
+--replace_regex $PATTERN
+--exec cat $MYSQLD_DATADIR/my_slow_test.log
+
+# Setting back connection to default, and cleanup.
+connection default;
+disconnect conn1;
+
 # As we tested with 1 before, we expect a "use ..." to appear with 0.
+
+# Clean slow query log file before test.
+--source include/slow_query_log_file_reset.inc
 
 --echo
 SET @@global.log_slow_extra_db = 0;

--- a/mysql-test/suite/sys_vars/t/log_slow_extra_db_func.test
+++ b/mysql-test/suite/sys_vars/t/log_slow_extra_db_func.test
@@ -1,0 +1,81 @@
+--echo # Bug#106645: Slow query log is not logging database/schema name.
+--echo
+
+--echo ## Save state.
+SET @global_log_output = @@global.log_output;
+SET @global_slow_query_log = @@global.slow_query_log;
+SET @global_slow_query_log_file = @@global.slow_query_log_file;
+SET @global_log_slow_extra = @@global.log_slow_extra;
+SET @global_log_slow_extra_db = @@global.log_slow_extra_db;
+
+--echo
+--echo ## Common to all tests below.
+
+let $MYSQLD_DATADIR= `select @@datadir`;
+
+# Setting slow_query_log_file before enabling the slow log to avoid creating a random file.
+SET @@global.slow_query_log_file = 'my_slow_test.log';
+
+SET @@global.log_output = 'FILE';
+SET @@global.slow_query_log = ON;
+
+# This needs to go after log_output as it might warn otherwise.
+SET @@global.log_slow_extra = 0;
+
+SET @@session.long_query_time = 0.1;
+
+# These regex patterns are for masking-out non-deterministic output.
+--let $PATTERN_VER= /.*Version.*started with.*\n//
+--let $PATTERN_TCP= /^Tcp port:.*Unix socket:.*\n//
+--let $PATTERN_TIME1= /^Time.*Id.*Command.*Argument.*\n//
+--let $PATTERN_TIME2= /^# Time: .*/# Time: x/
+
+# Replacing User@Host by UH as a trick to conserve "Db: ..." when it is there.
+--let $PATTERN_UH1= /^# User@Host:.*Id:.*Db:/# UH: n Id: n Db:/
+--let $PATTERN_UH2= /^# User@Host:.*Id:.*/# UH: n Id: n/
+
+--let $PATTERN_QT= /^# Query_time: .*Lock_time: .*Rows_sent:/# Query_time: n Lock_time: n Rows_sent:/
+--let $PATTERN_TS= /SET timestamp=.*\n//
+
+--let $PATTERN= $PATTERN_VER $PATTERN_TCP $PATTERN_TIME1 $PATTERN_TIME2 $PATTERN_UH1 $PATTERN_UH2 $PATTERN_QT $PATTERN_TS
+
+--source include/slow_query_log_file_reset.inc
+
+# We test log_slow_extra_db = 1 before 0 as we want to make sure a "use ..." appears with 0.
+
+--echo
+SET @@global.log_slow_extra_db = 1;
+SELECT sleep(0.5);
+
+--echo
+# Checking the content of the slow query log file.
+--replace_regex $PATTERN
+--exec cat $MYSQLD_DATADIR/my_slow_test.log
+
+--source include/slow_query_log_file_reset.inc
+
+# As we tested with 1 before, we expect a "use ..." to appear with 0.
+
+--echo
+SET @@global.log_slow_extra_db = 0;
+SELECT sleep(0.5);
+
+--echo
+# Checking the content of the slow query log file.
+--replace_regex $PATTERN
+--exec cat $MYSQLD_DATADIR/my_slow_test.log
+
+# Cleanup.
+--remove_file $MYSQLD_DATADIR/my_slow_test.log
+
+--echo
+--echo ## Restore state.
+# These need to go before log_output as they might warn otherwise.
+SET @@global.log_slow_extra = @global_log_slow_extra;
+SET @@global.log_slow_extra_db = @global_log_slow_extra_db;
+
+SET @@global.log_output = @global_log_output;
+SET @@global.slow_query_log = @global_slow_query_log;
+SET @@global.slow_query_log_file = @global_slow_query_log_file;
+
+# EOF.

--- a/mysql-test/suite/sys_vars/t/log_slow_extra_func.test
+++ b/mysql-test/suite/sys_vars/t/log_slow_extra_func.test
@@ -2,29 +2,9 @@
 --echo # WL#12393: Logging: Add new command line option for richer slow query logging
 --echo
 
---echo ## Save state.
-SET @global_log_output = @@global.log_output;
-SET @global_slow_query_log = @@global.slow_query_log;
-SET @global_slow_query_log_file = @@global.slow_query_log_file;
-SET @global_log_slow_extra = @@global.log_slow_extra;
-SET @global_log_slow_extra_db = @@global.log_slow_extra_db;
-
---echo
---echo ## Common to all tests below.
+# Common variables for all tests.
 
 let $MYSQLD_DATADIR= `select @@datadir`;
-
-# Setting slow_query_log_file before enabling the slow log to avoid creating a random file.
-SET @@global.slow_query_log_file = 'my_slow_test.log';
-
-SET @@global.log_output = 'FILE';
-SET @@global.slow_query_log = ON;
-
-# This needs to go after log_output as it might warn otherwise.
-# Doing tests with log_slow_extra_db = 1 allows not having to manage "use ..." in the output.
-SET @@global.log_slow_extra_db = 1;
-
-SET @@session.long_query_time = 0.1;
 
 # These regex patterns are for masking-out non-deterministic output.
 --let $PATTERN_VER= /.*Version.*started with.*\n//
@@ -40,6 +20,29 @@ SET @@session.long_query_time = 0.1;
 
 --let $PATTERN= $PATTERN_VER $PATTERN_TCP $PATTERN_TIME1 $PATTERN_TIME2 $PATTERN_UH $PATTERN_QT $PATTERN_THREAD $PATTERN_BR $PATTERN_START $PATTERN_TS
 
+--echo ## Save state.
+SET @global_log_output = @@global.log_output;
+SET @global_slow_query_log = @@global.slow_query_log;
+SET @global_slow_query_log_file = @@global.slow_query_log_file;
+SET @global_log_slow_extra = @@global.log_slow_extra;
+SET @global_log_slow_extra_db = @@global.log_slow_extra_db;
+
+--echo
+--echo ## Common to all tests below.
+
+# Setting slow_query_log_file before enabling the slow log to avoid creating a random file.
+SET @@global.slow_query_log_file = 'my_slow_test.log';
+
+SET @@global.log_output = 'FILE';
+SET @@global.slow_query_log = ON;
+
+# This needs to go after log_output as it might warn otherwise.
+# Doing tests with log_slow_extra_db = 1 allows not having to manage "use ..." in the output.
+SET @@global.log_slow_extra_db = 1;
+
+SET @@session.long_query_time = 0.1;
+
+# Clean slow query log file before test.
 --source include/slow_query_log_file_reset.inc
 
 --echo
@@ -51,6 +54,7 @@ SELECT sleep(0.5);
 --replace_regex $PATTERN
 --exec cat $MYSQLD_DATADIR/my_slow_test.log
 
+# Clean slow query log file before test.
 --source include/slow_query_log_file_reset.inc
 
 --echo

--- a/mysql-test/suite/sys_vars/t/log_slow_extra_func.test
+++ b/mysql-test/suite/sys_vars/t/log_slow_extra_func.test
@@ -1,0 +1,78 @@
+# This is contributed with Bug#106645, but this still is about WL#12393.
+--echo # WL#12393: Logging: Add new command line option for richer slow query logging
+--echo
+
+--echo ## Save state.
+SET @global_log_output = @@global.log_output;
+SET @global_slow_query_log = @@global.slow_query_log;
+SET @global_slow_query_log_file = @@global.slow_query_log_file;
+SET @global_log_slow_extra = @@global.log_slow_extra;
+SET @global_log_slow_extra_db = @@global.log_slow_extra_db;
+
+--echo
+--echo ## Common to all tests below.
+
+let $MYSQLD_DATADIR= `select @@datadir`;
+
+# Setting slow_query_log_file before enabling the slow log to avoid creating a random file.
+SET @@global.slow_query_log_file = 'my_slow_test.log';
+
+SET @@global.log_output = 'FILE';
+SET @@global.slow_query_log = ON;
+
+# This needs to go after log_output as it might warn otherwise.
+# Doing tests with log_slow_extra_db = 1 allows not having to manage "use ..." in the output.
+SET @@global.log_slow_extra_db = 1;
+
+SET @@session.long_query_time = 0.1;
+
+# These regex patterns are for masking-out non-deterministic output.
+--let $PATTERN_VER= /.*Version.*started with.*\n//
+--let $PATTERN_TCP= /^Tcp port:.*Unix socket:.*\n//
+--let $PATTERN_TIME1= /^Time.*Id.*Command.*Argument.*\n//
+--let $PATTERN_TIME2= /^# Time: .*/# Time: x/
+--let $PATTERN_UH= /^# User@Host:.*Id:.*Db:/# User@Host: n Id: n Db:/
+--let $PATTERN_QT= /^# Query_time: .*Lock_time: .*Rows_sent:/# Query_time: n Lock_time: n Rows_sent:/
+--let $PATTERN_THREAD= /Thread_id:.*Errno:/Thread_id: n Errno:/
+--let $PATTERN_BR= /Bytes_received:.*Bytes_sent:.*Read_first:/Bytes_received: n Bytes_sent: n Read_first:/
+--let $PATTERN_START= /Start:.*End:.*/Start: n End: n/
+--let $PATTERN_TS= /SET timestamp=.*\n//
+
+--let $PATTERN= $PATTERN_VER $PATTERN_TCP $PATTERN_TIME1 $PATTERN_TIME2 $PATTERN_UH $PATTERN_QT $PATTERN_THREAD $PATTERN_BR $PATTERN_START $PATTERN_TS
+
+--source include/slow_query_log_file_reset.inc
+
+--echo
+SET @@global.log_slow_extra = 0;
+SELECT sleep(0.5);
+
+--echo
+# Checking the content of the slow query log file.
+--replace_regex $PATTERN
+--exec cat $MYSQLD_DATADIR/my_slow_test.log
+
+--source include/slow_query_log_file_reset.inc
+
+--echo
+SET @@global.log_slow_extra = 1;
+SELECT sleep(0.5);
+
+--echo
+# Checking the content of the slow query log file.
+--replace_regex $PATTERN
+--exec cat $MYSQLD_DATADIR/my_slow_test.log
+
+# Cleanup.
+--remove_file $MYSQLD_DATADIR/my_slow_test.log
+
+--echo
+--echo ## Restore state.
+# These need to go before log_output as they might warn otherwise.
+SET @@global.log_slow_extra = @global_log_slow_extra;
+SET @@global.log_slow_extra_db = @global_log_slow_extra_db;
+
+SET @@global.log_output = @global_log_output;
+SET @@global.slow_query_log = @global_slow_query_log;
+SET @@global.slow_query_log_file = @global_slow_query_log_file;
+
+# EOF.

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -1200,6 +1200,7 @@ ulonglong log_output_options;
 bool opt_log_queries_not_using_indexes = false;
 ulong opt_log_throttle_queries_not_using_indexes = 0;
 bool opt_log_slow_extra = false;
+bool opt_log_slow_extra_db = true;
 bool opt_disable_networking = false, opt_skip_show_db = false;
 bool opt_skip_name_resolve = false;
 bool server_id_supplied = false;

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -167,6 +167,7 @@ extern ulonglong log_output_options;
 extern bool opt_log_queries_not_using_indexes;
 extern ulong opt_log_throttle_queries_not_using_indexes;
 extern bool opt_log_slow_extra;
+extern bool opt_log_slow_extra_db;
 extern bool opt_disable_networking, opt_skip_show_db;
 extern bool opt_skip_name_resolve;
 extern bool opt_help;

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -5854,6 +5854,9 @@ static Sys_var_bool Sys_slow_query_log(
     NOT_IN_BINLOG, ON_CHECK(nullptr), ON_UPDATE(fix_slow_log_state));
 
 static bool check_slow_log_extra(sys_var *, THD *thd, set_var *) {
+  /* This function is called by check_slow_log_extra_db.  If something specific
+   *   to slow_log_extra (not slow_log_extra_db) is added here, consider
+   *   updating check_slow_log_extra_db. */
   // If FILE is not one of the log-targets, succeed but warn!
   if (!(log_output_options & LOG_FILE))
     push_warning(
@@ -5870,6 +5873,19 @@ static Sys_var_bool Sys_slow_log_extra(
     "logging to table.",
     GLOBAL_VAR(opt_log_slow_extra), CMD_LINE(OPT_ARG), DEFAULT(false),
     NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(check_slow_log_extra),
+    ON_UPDATE(nullptr));
+
+static bool check_slow_log_extra_db(sys_var * sysv, THD *thd, set_var * setv) {
+  /* Exactly the same as check_slow_log_extra, let's not duplicate code. */
+  return check_slow_log_extra(sysv, thd, setv);
+}
+
+static Sys_var_bool Sys_slow_log_extra_db(
+    "log_slow_extra_db",
+    "Print db to the slow query log file. Has no effect on "
+    "logging to table.",
+    GLOBAL_VAR(opt_log_slow_extra_db), CMD_LINE(OPT_ARG), DEFAULT(true),
+    NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(check_slow_log_extra_db),
     ON_UPDATE(nullptr));
 
 static bool check_not_empty_set(sys_var *, THD *, set_var *var) {


### PR DESCRIPTION
This PR adds database / schema in the slow query log file, implementing the feature request [Bug#106645: Slow query log is not logging database/schema name](https://bugs.mysql.com/bug.php?id=106645).

In case, at the same time as merging this contribution, it makes sense to fix [Bug#115203](https://bugs.mysql.com/bug.php?id=115203), this PR also includes a commented fix for that bug (Empty "use ;" on replica in slow query log file).

I wrote a full blog post on this work: [RFC: Database / Schema in the Slow Query Log File](https://jfg-mysql.blogspot.com/2024/06/rfc-database-schema-in-slow-query-log-file.html).  It contains more context about this work, but reading it is not absolutely needed to comment on this PR.

This is a "RFC Fake PR".  It is there so people can comment on this work in case it needs adjustments. This will eventually be contributed as a patch file in [Bug#106645](https://bugs.mysql.com/bug.php?id=106645).  More about this in the above-mentioned blog post this in the section [Fake PRs and my Way of Working on MySQL Contributions](https://jfg-mysql.blogspot.com/2024/06/rfc-database-schema-in-slow-query-log-file.html#my_way_of_working_on_mysql_contributions).

This PR merges on 8.4.0.  The corresponding patch file does not apply on 8.0.37, but the commit of this PR can be cherry-picked in a branch from the 8.0.37 tag (and the mtr tests of this work pass in 8.0.37).

For implementing database / schema in the slow query log file, this PR introduces a new global variable: `log_slow_extra_db`.  It is `ON` by default, and can be set to `OFF` to keep the current 8.4.0 (and 8.0.37) behavior (in case of changing the format of the slow query log file breaks tooling parsing the file).  This variable should eventually be deprecated to reduce code complexity (I have chosen not to introduce it as deprecated, if Oracle prefers that and notifies me, I will update the PR).

With `log_slow_extra_db = ON`, we have below in the slow query log file (see `Db: test_jfg` at the end of the second line).
```
# Time: 2024-05-23T18:45:31.526893Z
# User@Host: msandbox[msandbox] @ localhost []  Id:    12  Db: test_jfg
# Query_time: 1.000486  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 1
SET timestamp=1716489930;
select sleep(1), t.* from t;
```

And with `OFF`, we have this (current 8.4.0 and 8.0.37 behavior):
```
# Time: 2024-05-23T18:48:06.989986Z
# User@Host: msandbox[msandbox] @ localhost []  Id:    13
# Query_time: 1.000381  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 1
use test_jfg;
SET timestamp=1716490085;
select sleep(1), t.* from t;
```

With `log_slow_extra_db` to `ON`, all `use ...` are removed from the slow query log file (note the `use ...` in above with `log_slow_extra_db = OFF`).  Another option for adding database / schema in the slow query log file is to always put `use ...` in the file, but this could be weird for queries run in no specific schema (no `use ...` in this specific case ?).  An interesting thing about always having `use ...` is that this does not change the format of the file, and if enough people think this is better, I will change the implementation before contributing.  A way to "vote" on this is to react to the [matching comment](https://github.com/jfg956/mysql-server/pull/9#issuecomment-2160856062) below.

I choose `Db` as the name of the new field in the slow query log file as it matches the name of the column in the `mysql.slow_log` table.  It could be something else, and if enough people think `Schema` or something else should be used, I will update the implementation before contributing.    A way to "vote" on this is to react to the [matching comment](https://github.com/jfg956/mysql-server/pull/9#issuecomment-2160858796) below.

About queries run in no specific schema, this PR puts `NoDb` instead of `Db: ...` in the file.  There is another option: putting the empty-string database (`Db: \n`), but `NoDb` looked "cleaner" to me.  If enough people think the empty-string db should be used, I will update the implementation before contributing.    A way to "vote" on this is to react to the [matching comment](https://github.com/jfg956/mysql-server/pull/9#issuecomment-2160862534) below.

Ideally, in addition to being included in a next Innovation Release, this work would be back-ported in 8.4 and 8.0.  The only change I see for the back-port would be to set the default for `log_slow_extra_db` to `OFF` to avoid introducing a potentially breaking change.

More JFG development notes:
- Work branch: https://github.com/jfg956/mysql-server/tree/mysql-8.4.0_bug106645
- Brain dump: https://github.com/jfg956/mysql-server/blob/mysql-8.4.0_bug106645/jfg_brain_dump.md