### PR TITLE
Contrib Fake PR: Implement Bug#106645: Slow query log is not logging database/schema name.

### DIFF
--- a/mysql-test/include/slow_query_log_file_reset.inc
+++ b/mysql-test/include/slow_query_log_file_reset.inc
@@ -1,0 +1,8 @@
+
+let $_INTERNAL_MYSQLD_DATADIR = `select @@datadir`;
+let $_INTERNAL_MYSQLD_SLOW_QUERY_LOG_FILE = `select @@slow_query_log_file`;
+
+--echo
+--echo ## Resetting the slow query log file.
+--remove_file $MYSQLD_DATADIR/$_INTERNAL_MYSQLD_SLOW_QUERY_LOG_FILE
+FLUSH SLOW LOGS;

--- a/mysql-test/suite/sys_vars/r/log_slow_extra_db_basic.result
+++ b/mysql-test/suite/sys_vars/r/log_slow_extra_db_basic.result
@@ -1,0 +1,87 @@
+# Bug#106645: Slow query log is not logging database/schema name.
+
+# test global variable "log_slow_extra_db"
+
+SELECT @@global.log_slow_extra_db INTO @old_lsed;
+SELECT @@global.log_output        INTO @old_lo;
+SELECT @@global.slow_query_log    INTO @old_sql;
+# invalid values / types
+SET GLOBAL log_slow_extra_db=symbol;
+ERROR 42000: Variable 'log_slow_extra_db' can't be set to the value of 'symbol'
+SET GLOBAL log_slow_extra_db="string";
+ERROR 42000: Variable 'log_slow_extra_db' can't be set to the value of 'string'
+SET GLOBAL log_slow_extra_db=99;
+ERROR 42000: Variable 'log_slow_extra_db' can't be set to the value of '99'
+SET GLOBAL log_slow_extra_db=0.5;
+ERROR 42000: Incorrect argument type to variable 'log_slow_extra_db'
+
+# only GLOBAL scope is valid
+SET SESSION log_slow_extra_db=0;
+ERROR HY000: Variable 'log_slow_extra_db' is a GLOBAL variable and should be set with SET GLOBAL
+
+# valid values
+SET GLOBAL slow_query_log=0;
+SET GLOBAL log_slow_extra_db=0;
+SELECT @@global.log_slow_extra_db;
+@@global.log_slow_extra_db
+0
+SET GLOBAL log_slow_extra_db=1;
+SELECT @@global.log_slow_extra_db;
+@@global.log_slow_extra_db
+1
+SET GLOBAL log_slow_extra_db=OFF;
+SELECT @@global.log_slow_extra_db;
+@@global.log_slow_extra_db
+0
+SET GLOBAL log_slow_extra_db=ON;
+SELECT @@global.log_slow_extra_db;
+@@global.log_slow_extra_db
+1
+SET GLOBAL log_slow_extra_db=DEFAULT;
+SELECT @@global.log_slow_extra_db;
+@@global.log_slow_extra_db
+1
+
+# warnings and errors
+SET GLOBAL slow_query_log=1;
+
+# Switching slow query log file format while target is not FILE is legal,
+# but does nothing. Throw a warning!
+SET GLOBAL log_output="TABLE";
+SELECT @@global.log_slow_extra_db INTO @old;
+SET GLOBAL log_slow_extra_db=0;
+Warnings:
+Warning	3795	slow query log file format changed as requested, but setting will have no effect when not actually logging to a file.
+# Value must have changed:
+SELECT @@global.log_slow_extra_db!=@old;
+@@global.log_slow_extra_db!=@old
+1
+SET GLOBAL log_slow_extra_db=DEFAULT;
+Warnings:
+Warning	3795	slow query log file format changed as requested, but setting will have no effect when not actually logging to a file.
+
+# Switching slow query log file format while target is not FILE is legal,
+# but does nothing. Throw a warning!
+SET GLOBAL log_output="NONE";
+SELECT @@global.log_slow_extra_db INTO @old;
+SET GLOBAL log_slow_extra_db=0;
+Warnings:
+Warning	3795	slow query log file format changed as requested, but setting will have no effect when not actually logging to a file.
+# Value must have changed:
+SELECT @@global.log_slow_extra_db!=@old;
+@@global.log_slow_extra_db!=@old
+1
+SET GLOBAL log_slow_extra_db=DEFAULT;
+Warnings:
+Warning	3795	slow query log file format changed as requested, but setting will have no effect when not actually logging to a file.
+
+# clean up
+SET GLOBAL log_slow_extra_db=@old_lsed;
+Warnings:
+Warning	3795	slow query log file format changed as requested, but setting will have no effect when not actually logging to a file.
+SET GLOBAL log_output=@old_lo;
+SET GLOBAL slow_query_log=@old_sql;
+TRUNCATE TABLE mysql.general_log;
+TRUNCATE TABLE mysql.slow_log;
+
+# READY

--- a/mysql-test/suite/sys_vars/r/log_slow_extra_db_func.result
+++ b/mysql-test/suite/sys_vars/r/log_slow_extra_db_func.result
@@ -1,0 +1,62 @@
+# Bug#106645: Slow query log is not logging database/schema name.
+
+## Save state.
+SET @global_log_output = @@global.log_output;
+SET @global_slow_query_log = @@global.slow_query_log;
+SET @global_slow_query_log_file = @@global.slow_query_log_file;
+SET @global_log_slow_extra = @@global.log_slow_extra;
+SET @global_log_slow_extra_db = @@global.log_slow_extra_db;
+
+## Common to all tests below.
+SET @@global.slow_query_log_file = 'my_slow_test.log';
+SET @@global.log_output = 'FILE';
+SET @@global.slow_query_log = ON;
+SET @@global.log_slow_extra = 0;
+SET @@session.long_query_time = 0.1;
+
+## Resetting the slow query log file.
+FLUSH SLOW LOGS;
+
+SET @@global.log_slow_extra_db = 1;
+SELECT sleep(0.5);
+sleep(0.5)
+0
+
+# Time: x
+# UH: n Id: n Db: test
+# Query_time: n Lock_time: n Rows_sent: 1  Rows_examined: 1
+SELECT sleep(0.5);
+
+## Resetting the slow query log file.
+FLUSH SLOW LOGS;
+
+SET @@session.long_query_time = 0.1;
+SELECT sleep(0.5);
+sleep(0.5)
+0
+
+# Time: x
+# UH: n Id: n Db: 
+# Query_time: n Lock_time: n Rows_sent: 1  Rows_examined: 1
+SELECT sleep(0.5);
+
+## Resetting the slow query log file.
+FLUSH SLOW LOGS;
+
+SET @@global.log_slow_extra_db = 0;
+SELECT sleep(0.5);
+sleep(0.5)
+0
+
+# Time: x
+# UH: n Id: n
+# Query_time: n Lock_time: n Rows_sent: 1  Rows_examined: 1
+use test;
+SELECT sleep(0.5);
+
+## Restore state.
+SET @@global.log_slow_extra = @global_log_slow_extra;
+SET @@global.log_slow_extra_db = @global_log_slow_extra_db;
+SET @@global.log_output = @global_log_output;
+SET @@global.slow_query_log = @global_slow_query_log;
+SET @@global.slow_query_log_file = @global_slow_query_log_file;

--- a/mysql-test/suite/sys_vars/r/log_slow_extra_func.result
+++ b/mysql-test/suite/sys_vars/r/log_slow_extra_func.result
@@ -1,0 +1,48 @@
+# WL#12393: Logging: Add new command line option for richer slow query logging
+
+## Save state.
+SET @global_log_output = @@global.log_output;
+SET @global_slow_query_log = @@global.slow_query_log;
+SET @global_slow_query_log_file = @@global.slow_query_log_file;
+SET @global_log_slow_extra = @@global.log_slow_extra;
+SET @global_log_slow_extra_db = @@global.log_slow_extra_db;
+
+## Common to all tests below.
+SET @@global.slow_query_log_file = 'my_slow_test.log';
+SET @@global.log_output = 'FILE';
+SET @@global.slow_query_log = ON;
+SET @@global.log_slow_extra_db = 1;
+SET @@session.long_query_time = 0.1;
+
+## Resetting the slow query log file.
+FLUSH SLOW LOGS;
+
+SET @@global.log_slow_extra = 0;
+SELECT sleep(0.5);
+sleep(0.5)
+0
+
+# Time: x
+# User@Host: n Id: n Db: test
+# Query_time: n Lock_time: n Rows_sent: 1  Rows_examined: 1
+SELECT sleep(0.5);
+
+## Resetting the slow query log file.
+FLUSH SLOW LOGS;
+
+SET @@global.log_slow_extra = 1;
+SELECT sleep(0.5);
+sleep(0.5)
+0
+
+# Time: x
+# User@Host: n Id: n Db: test
+# Query_time: n Lock_time: n Rows_sent: 1  Rows_examined: 1 Thread_id: n Errno: 0 Killed: 0 Bytes_received: n Bytes_sent: n Read_first: 0 Read_last: 0 Read_key: 0 Read_next: 0 Read_prev: 0 Read_rnd: 0 Read_rnd_next: 0 Sort_merge_passes: 0 Sort_range_count: 0 Sort_rows: 0 Sort_scan_count: 0 Created_tmp_disk_tables: 0 Created_tmp_tables: 0 Start: n End: n
+SELECT sleep(0.5);
+
+## Restore state.
+SET @@global.log_slow_extra = @global_log_slow_extra;
+SET @@global.log_slow_extra_db = @global_log_slow_extra_db;
+SET @@global.log_output = @global_log_output;
+SET @@global.slow_query_log = @global_slow_query_log;
+SET @@global.slow_query_log_file = @global_slow_query_log_file;

--- a/mysql-test/suite/sys_vars/t/log_slow_extra_db_basic.test
+++ b/mysql-test/suite/sys_vars/t/log_slow_extra_db_basic.test
@@ -1,0 +1,86 @@
+--echo # Bug#106645: Slow query log is not logging database/schema name.
+--echo
+--echo # test global variable "log_slow_extra_db"
+--echo
+
+SELECT @@global.log_slow_extra_db INTO @old_lsed;
+SELECT @@global.log_output        INTO @old_lo;
+SELECT @@global.slow_query_log    INTO @old_sql;
+
+--echo # invalid values / types
+
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL log_slow_extra_db=symbol;
+
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL log_slow_extra_db="string";
+
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL log_slow_extra_db=99;
+
+--error ER_WRONG_TYPE_FOR_VAR
+SET GLOBAL log_slow_extra_db=0.5;
+
+--echo
+--echo # only GLOBAL scope is valid
+
+--error ER_GLOBAL_VARIABLE
+SET SESSION log_slow_extra_db=0;
+
+--echo
+
+--echo # valid values
+SET GLOBAL slow_query_log=0;
+
+SET GLOBAL log_slow_extra_db=0;
+SELECT @@global.log_slow_extra_db;
+
+SET GLOBAL log_slow_extra_db=1;
+SELECT @@global.log_slow_extra_db;
+
+SET GLOBAL log_slow_extra_db=OFF;
+SELECT @@global.log_slow_extra_db;
+
+SET GLOBAL log_slow_extra_db=ON;
+SELECT @@global.log_slow_extra_db;
+
+SET GLOBAL log_slow_extra_db=DEFAULT;
+SELECT @@global.log_slow_extra_db;
+
+--echo
+
+--echo # warnings and errors
+
+SET GLOBAL slow_query_log=1;
+--echo
+
+--echo # Switching slow query log file format while target is not FILE is legal,
+--echo # but does nothing. Throw a warning!
+SET GLOBAL log_output="TABLE";
+SELECT @@global.log_slow_extra_db INTO @old;
+SET GLOBAL log_slow_extra_db=0;
+--echo # Value must have changed:
+SELECT @@global.log_slow_extra_db!=@old;
+SET GLOBAL log_slow_extra_db=DEFAULT;
+--echo
+
+--echo # Switching slow query log file format while target is not FILE is legal,
+--echo # but does nothing. Throw a warning!
+SET GLOBAL log_output="NONE";
+SELECT @@global.log_slow_extra_db INTO @old;
+SET GLOBAL log_slow_extra_db=0;
+--echo # Value must have changed:
+SELECT @@global.log_slow_extra_db!=@old;
+SET GLOBAL log_slow_extra_db=DEFAULT;
+--echo
+
+--echo # clean up
+SET GLOBAL log_slow_extra_db=@old_lsed;
+SET GLOBAL log_output=@old_lo;
+SET GLOBAL slow_query_log=@old_sql;
+TRUNCATE TABLE mysql.general_log;
+TRUNCATE TABLE mysql.slow_log;
+
+--echo
+
+--echo # READY

--- a/mysql-test/suite/sys_vars/t/log_slow_extra_db_func.test
+++ b/mysql-test/suite/sys_vars/t/log_slow_extra_db_func.test
@@ -1,0 +1,109 @@
+--echo # Bug#106645: Slow query log is not logging database/schema name.
+--echo
+
+# Common variables for all tests.
+
+--let $MYSQLD_DATADIR= `select @@datadir`
+
+# These regex patterns are for masking-out non-deterministic output.
+--let $PATTERN_VER= /.*Version.*started with.*\n//
+--let $PATTERN_TCP= /^Tcp port:.*Unix socket:.*\n//
+--let $PATTERN_TIME1= /^Time.*Id.*Command.*Argument.*\n//
+--let $PATTERN_TIME2= /^# Time: .*/# Time: x/
+
+# Replacing User@Host by UH as a trick to conserve "Db: ..." when it is there.
+--let $PATTERN_UH1= /^# User@Host:.*Id:.*Db:/# UH: n Id: n Db:/
+--let $PATTERN_UH2= /^# User@Host:.*Id:.*/# UH: n Id: n/
+
+--let $PATTERN_QT= /^# Query_time: .*Lock_time: .*Rows_sent:/# Query_time: n Lock_time: n Rows_sent:/
+--let $PATTERN_TS= /SET timestamp=.*\n//
+
+--let $PATTERN= $PATTERN_VER $PATTERN_TCP $PATTERN_TIME1 $PATTERN_TIME2 $PATTERN_UH1 $PATTERN_UH2 $PATTERN_QT $PATTERN_TS
+
+--echo ## Save state.
+SET @global_log_output = @@global.log_output;
+SET @global_slow_query_log = @@global.slow_query_log;
+SET @global_slow_query_log_file = @@global.slow_query_log_file;
+SET @global_log_slow_extra = @@global.log_slow_extra;
+SET @global_log_slow_extra_db = @@global.log_slow_extra_db;
+
+--echo
+--echo ## Common to all tests below.
+
+# Setting slow_query_log_file before enabling the slow log to avoid creating a random file.
+SET @@global.slow_query_log_file = 'my_slow_test.log';
+
+SET @@global.log_output = 'FILE';
+SET @@global.slow_query_log = ON;
+
+# This needs to go after log_output as it might warn otherwise.
+SET @@global.log_slow_extra = 0;
+
+SET @@session.long_query_time = 0.1;
+
+# We test log_slow_extra_db = 1 before 0 as we want to make sure a "use ..." appears with 0.
+
+# Clean slow query log file before test.
+--source include/slow_query_log_file_reset.inc
+
+--echo
+SET @@global.log_slow_extra_db = 1;
+SELECT sleep(0.5);
+
+--echo
+# Checking the content of the slow query log file.
+--replace_regex $PATTERN
+--exec cat $MYSQLD_DATADIR/my_slow_test.log
+
+# New connection with no selected database.
+# Below from the doc...
+# https://dev.mysql.com/doc/dev/mysql-server/latest/PAGE_MYSQL_TEST_COMMANDS.html
+#   connect (name, host_name, user_name, password, db_name [,port_num ... 
+#   *NO-ONE* means that no default database should be selected
+--connect(conn1,localhost,root,,*NO-ONE*)
+connection conn1;
+
+# Clean slow query log file before test.
+--source include/slow_query_log_file_reset.inc
+
+--echo
+SET @@session.long_query_time = 0.1;
+SELECT sleep(0.5);
+
+--echo
+# Checking the content of the slow query log file.
+--replace_regex $PATTERN
+--exec cat $MYSQLD_DATADIR/my_slow_test.log
+
+# Setting back connection to default, and cleanup.
+connection default;
+disconnect conn1;
+
+# As we tested with 1 before, we expect a "use ..." to appear with 0.
+
+# Clean slow query log file before test.
+--source include/slow_query_log_file_reset.inc
+
+--echo
+SET @@global.log_slow_extra_db = 0;
+SELECT sleep(0.5);
+
+--echo
+# Checking the content of the slow query log file.
+--replace_regex $PATTERN
+--exec cat $MYSQLD_DATADIR/my_slow_test.log
+
+# Cleanup.
+--remove_file $MYSQLD_DATADIR/my_slow_test.log
+
+--echo
+--echo ## Restore state.
+# These need to go before log_output as they might warn otherwise.
+SET @@global.log_slow_extra = @global_log_slow_extra;
+SET @@global.log_slow_extra_db = @global_log_slow_extra_db;
+
+SET @@global.log_output = @global_log_output;
+SET @@global.slow_query_log = @global_slow_query_log;
+SET @@global.slow_query_log_file = @global_slow_query_log_file;
+
+# EOF.

--- a/mysql-test/suite/sys_vars/t/log_slow_extra_func.test
+++ b/mysql-test/suite/sys_vars/t/log_slow_extra_func.test
@@ -1,0 +1,82 @@
+# This is contributed with Bug#106645, but this still is about WL#12393.
+--echo # WL#12393: Logging: Add new command line option for richer slow query logging
+--echo
+
+# Common variables for all tests.
+
+let $MYSQLD_DATADIR= `select @@datadir`;
+
+# These regex patterns are for masking-out non-deterministic output.
+--let $PATTERN_VER= /.*Version.*started with.*\n//
+--let $PATTERN_TCP= /^Tcp port:.*Unix socket:.*\n//
+--let $PATTERN_TIME1= /^Time.*Id.*Command.*Argument.*\n//
+--let $PATTERN_TIME2= /^# Time: .*/# Time: x/
+--let $PATTERN_UH= /^# User@Host:.*Id:.*Db:/# User@Host: n Id: n Db:/
+--let $PATTERN_QT= /^# Query_time: .*Lock_time: .*Rows_sent:/# Query_time: n Lock_time: n Rows_sent:/
+--let $PATTERN_THREAD= /Thread_id:.*Errno:/Thread_id: n Errno:/
+--let $PATTERN_BR= /Bytes_received:.*Bytes_sent:.*Read_first:/Bytes_received: n Bytes_sent: n Read_first:/
+--let $PATTERN_START= /Start:.*End:.*/Start: n End: n/
+--let $PATTERN_TS= /SET timestamp=.*\n//
+
+--let $PATTERN= $PATTERN_VER $PATTERN_TCP $PATTERN_TIME1 $PATTERN_TIME2 $PATTERN_UH $PATTERN_QT $PATTERN_THREAD $PATTERN_BR $PATTERN_START $PATTERN_TS
+
+--echo ## Save state.
+SET @global_log_output = @@global.log_output;
+SET @global_slow_query_log = @@global.slow_query_log;
+SET @global_slow_query_log_file = @@global.slow_query_log_file;
+SET @global_log_slow_extra = @@global.log_slow_extra;
+SET @global_log_slow_extra_db = @@global.log_slow_extra_db;
+
+--echo
+--echo ## Common to all tests below.
+
+# Setting slow_query_log_file before enabling the slow log to avoid creating a random file.
+SET @@global.slow_query_log_file = 'my_slow_test.log';
+
+SET @@global.log_output = 'FILE';
+SET @@global.slow_query_log = ON;
+
+# This needs to go after log_output as it might warn otherwise.
+# Doing tests with log_slow_extra_db = 1 allows not having to manage "use ..." in the output.
+SET @@global.log_slow_extra_db = 1;
+
+SET @@session.long_query_time = 0.1;
+
+# Clean slow query log file before test.
+--source include/slow_query_log_file_reset.inc
+
+--echo
+SET @@global.log_slow_extra = 0;
+SELECT sleep(0.5);
+
+--echo
+# Checking the content of the slow query log file.
+--replace_regex $PATTERN
+--exec cat $MYSQLD_DATADIR/my_slow_test.log
+
+# Clean slow query log file before test.
+--source include/slow_query_log_file_reset.inc
+
+--echo
+SET @@global.log_slow_extra = 1;
+SELECT sleep(0.5);
+
+--echo
+# Checking the content of the slow query log file.
+--replace_regex $PATTERN
+--exec cat $MYSQLD_DATADIR/my_slow_test.log
+
+# Cleanup.
+--remove_file $MYSQLD_DATADIR/my_slow_test.log
+
+--echo
+--echo ## Restore state.
+# These need to go before log_output as they might warn otherwise.
+SET @@global.log_slow_extra = @global_log_slow_extra;
+SET @@global.log_slow_extra_db = @global_log_slow_extra_db;
+
+SET @@global.log_output = @global_log_output;
+SET @@global.slow_query_log = @global_slow_query_log;
+SET @@global.slow_query_log_file = @global_slow_query_log_file;
+
+# EOF.

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -693,11 +693,21 @@ bool File_query_log::write_slow(THD *thd, ulonglong current_utime,
                                 size_t sql_text_len) {
   char buff[80], *end;
   char query_time_buff[22 + 7], lock_time_buff[22 + 7];
-  size_t buff_len;
-  end = buff;
+
+  /* In my patch for Bug#106645, I am allowing myself to change the initial assignment of end
+   *   from buff to NULL and assigning it to buff when it is used.  IMHO it makes clearer
+   *   that there are many independent usages of buff in this function,
+   *   but feel free to revert if you do not like it. */
+  /* Will be set to buff below, but setting to NULL now to make clear when this is used.
+   * Cannot declare when used as "goto err" would cross a declaration / initialization boundary. */
+  end = NULL;
 
   mysql_mutex_lock(&LOCK_log);
   assert(is_open());
+
+  /* For only logging db changes when db is not in the comment line.
+   * With SPECIAL_SHORT_LOG_FORMAT, always log db changes because no comment line. */
+  bool log_db_change = true;
 
   if (!(specialflag & SPECIAL_SHORT_LOG_FORMAT)) {
     char my_timestamp[iso8601_size];
@@ -705,15 +715,36 @@ bool File_query_log::write_slow(THD *thd, ulonglong current_utime,
     make_iso8601_timestamp(my_timestamp, current_utime,
                            iso8601_sysvar_logtimestamps);
 
-    buff_len = snprintf(buff, sizeof buff, "# Time: %s\n", my_timestamp);
+    /* In my patch for Bug#106645, I am allowing myself to inline the declaration of buff_len.
+     *   IMHO, this makes things better as after removing the usage of buff_len further down below,
+     *   here is the only place where it is used, but feel free to revert if you do not like it. */
+    size_t buff_len = snprintf(buff, sizeof buff, "# Time: %s\n", my_timestamp);
 
     /* Note that my_b_write() assumes it knows the length for this */
     if (my_b_write(&log_file, (uchar *)buff, buff_len)) goto err;
 
-    buff_len = snprintf(buff, 32, "%5u", thd->thread_id());
-    if (my_b_printf(&log_file, "# User@Host: %s  Id: %s\n", user_host, buff) ==
-        (uint)-1)
-      goto err;
+    if (!opt_log_slow_extra_db) {
+      /* This section of code will eventually be removed when everyone will be used
+       *   to the new slow query log file format with "Db:". */
+      snprintf(buff, 32, "%5u", thd->thread_id());
+      if (my_b_printf(&log_file, "# User@Host: %s  Id: %s\n", user_host, buff) == (uint)-1)
+        goto err;
+    } else {
+      log_db_change = false;
+      db[0] = 0;  /* Resetting db triggers logging db change after disabling log_slow_extra_db. */
+
+      /* When no schema is selected, str is null on the primary and empty-string on replicas ¯\_(ツ)_/¯.
+       * It does not matter much here, but  leaving a comment in case it matters in the future.
+       * This "weirdness" is the source of Bug#115203. */
+      const char *db4file = thd->db().str ? thd->db().str : "";
+
+      /* In my patch for Bug#106645, I am allowing myself to change the format of Id.
+       *   This avoids a snprintf, and is more consistent with Thread_id below (which looks better).
+       *   IMHO, adding Db is the right time to improve on the formatting of this line,
+       *   but feel free to revert if you do not like it. */
+      if (my_b_printf(&log_file, "# User@Host: %s  Id: %lu  Db: %s\n", user_host, (ulong)thd->thread_id(), db4file) == (uint)-1)
+        goto err;
+    }
   }
 
   /* For slow query log */
@@ -802,11 +833,23 @@ bool File_query_log::write_slow(THD *thd, ulonglong current_utime,
       goto err; /* purecov: inspected */
   }
 
-  if (thd->db().str && strcmp(thd->db().str, db)) {  // Database changed
+  /* Adding "&& thd->db().length > 0" would solve Bug#115203,
+   *   but as out of scope of Bug#106645, not done in this patch
+   *    (feel free to fix Bug#115203 before merging this patch). */
+  if (log_db_change && thd->db().str /*&& thd->db().length > 0*/ && strcmp(thd->db().str, db)) {
     if (my_b_printf(&log_file, "use %s;\n", thd->db().str) == (uint)-1)
       goto err;
     my_stpcpy(db, thd->db().str);
   }
+
+  /* In my patch for Bug#106645, I am allowing myself to change the initial assignment of end
+   *   from buff to NULL and assigning it to buff here.  IMHO it makes clearer that all usage of buff
+   *   above are irrelevant to the code below, but feel free to revert if you do not like it. */
+  /* Re-assigning end to make clear it is not used in above.
+   * We cannot declare / initialize here as "goto err" would cross
+   *   a declaration / initialization boundary. */
+  end = buff;
+
   if (thd->stmt_depends_on_first_successful_insert_id_in_prev_stmt) {
     end = my_stpcpy(end, ",last_insert_id=");
     end = longlong10_to_str(
@@ -840,10 +883,12 @@ bool File_query_log::write_slow(THD *thd, ulonglong current_utime,
   }
   if (is_command) {
     end = strxmov(buff, "# administrator command: ", NullS);
-    buff_len = (ulong)(end - buff);
     DBUG_EXECUTE_IF("simulate_slow_log_write_error",
                     { DBUG_SET("+d,simulate_file_write_error"); });
-    if (my_b_write(&log_file, (uchar *)buff, buff_len)) goto err;
+    /* In my patch for Bug#106645, I am allowing myself to remove the usage of the buff_len
+     *   variable in below.  IMHO, it is better code as it does not reuse this variable,
+     *   but feel free to revert if you do not like it. */
+    if (my_b_write(&log_file, (uchar *)buff, (ulong)(end - buff))) goto err;
   }
   if (my_b_write(&log_file, pointer_cast<const uchar *>(sql_text),
                  sql_text_len) ||

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -1200,6 +1200,7 @@ ulonglong log_output_options;
 bool opt_log_queries_not_using_indexes = false;
 ulong opt_log_throttle_queries_not_using_indexes = 0;
 bool opt_log_slow_extra = false;
+bool opt_log_slow_extra_db = true;
 bool opt_disable_networking = false, opt_skip_show_db = false;
 bool opt_skip_name_resolve = false;
 bool server_id_supplied = false;

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -167,6 +167,7 @@ extern ulonglong log_output_options;
 extern bool opt_log_queries_not_using_indexes;
 extern ulong opt_log_throttle_queries_not_using_indexes;
 extern bool opt_log_slow_extra;
+extern bool opt_log_slow_extra_db;
 extern bool opt_disable_networking, opt_skip_show_db;
 extern bool opt_skip_name_resolve;
 extern bool opt_help;

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -5854,6 +5854,9 @@ static Sys_var_bool Sys_slow_query_log(
     NOT_IN_BINLOG, ON_CHECK(nullptr), ON_UPDATE(fix_slow_log_state));
 
 static bool check_slow_log_extra(sys_var *, THD *thd, set_var *) {
+  /* This function is called by check_slow_log_extra_db.  If something specific
+   *   to slow_log_extra (not slow_log_extra_db) is added here, consider
+   *   updating check_slow_log_extra_db. */
   // If FILE is not one of the log-targets, succeed but warn!
   if (!(log_output_options & LOG_FILE))
     push_warning(
@@ -5870,6 +5873,19 @@ static Sys_var_bool Sys_slow_log_extra(
     "logging to table.",
     GLOBAL_VAR(opt_log_slow_extra), CMD_LINE(OPT_ARG), DEFAULT(false),
     NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(check_slow_log_extra),
+    ON_UPDATE(nullptr));
+
+static bool check_slow_log_extra_db(sys_var * sysv, THD *thd, set_var * setv) {
+  /* Exactly the same as check_slow_log_extra, let's not duplicate code. */
+  return check_slow_log_extra(sysv, thd, setv);
+}
+
+static Sys_var_bool Sys_slow_log_extra_db(
+    "log_slow_extra_db",
+    "Print db to the slow query log file. Has no effect on "
+    "logging to table.",
+    GLOBAL_VAR(opt_log_slow_extra_db), CMD_LINE(OPT_ARG), DEFAULT(true),
+    NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(check_slow_log_extra_db),
     ON_UPDATE(nullptr));
 
 static bool check_not_empty_set(sys_var *, THD *, set_var *var) {


### PR DESCRIPTION
This PR adds database / schema in the slow query log file, implementing the feature request [Bug#106645: Slow query log is not logging database/schema name](https://bugs.mysql.com/bug.php?id=106645).

In case, at the same time as merging this contribution, it makes sense to fix [Bug#115203](https://bugs.mysql.com/bug.php?id=115203), this PR also includes a commented fix for that bug (Empty "use ;" on replica in slow query log file).

This is a "Contrib Fake PR". It is there so people can comment on this work in case it needs adjustments. This has be contributed on 2024-07-12 as a patch file in [Bug#106645](https://bugs.mysql.com/bug.php?id=106645).  More about this in the RFC blog post, section [Fake PRs and my Way of Working on MySQL Contributions](https://jfg-mysql.blogspot.com/2024/06/rfc-database-schema-in-slow-query-log-file.html#my_way_of_working_on_mysql_contributions).

This PR merges on 8.4.0, and the corresponding patch file applies on 8.4.1 and 9.0.0.  It does not apply on 8.0.38, but the commit of this PR can be cherry-picked in a branch from the 8.0.38 tag.  The mtr tests of this work pass in all of 8.0.38, 8.4.0, 8.4.1 and 9.0.0.

For implementing database / schema in the slow query log file, this PR introduces a new global variable: `log_slow_extra_db`.  It is `ON` by default, and can be set to `OFF` to keep the current 9.0, 8.4 and 8.0 behavior (in case of changing the format of the slow query log file breaks tooling parsing the file). This variable should eventually be deprecated to reduce code complexity (I have chosen not to introduce it as deprecated, if Oracle prefers that and notifies me, I will update the PR).

Ideally, in addition to being included in a next Innovation Release, this would be back-ported in 8.4 and 8.0.  For back-porting, the default value of the global variable `log_slow_extra_db` should be set to `false` to avoid a breaking change.

Note that with `log_slow_extra_db = ON`, all `use ...` are removed from the slow query log file.

Also note that with `log_slow_extra_db = ON`, there is a **minor** change in the format of the `User@Host` line of the slow query log file.  Before, it was `# User@Host: %s  Id: %s`, with `Id: %s` being a `%5u`.  With `log_slow_extra_db = ON`, it is `# User@Host: %s  Id: %lu  Db: %s` which is consistent with the way `Thread_id` is logged with [`log_slow_extra`](https://dev.mysql.com/doc/refman/8.4/en/server-system-variables.html#sysvar_log_slow_extra).  It looks like the right time to improve on the formatting of this line (adding a new field and this change being behind a feature-flag), but Oracle can revert this if they do not like it (I can adapt the PR if they ask me to).

Examples of logs with and without the feature enabled in the [1st PR comment](https://github.com/jfg956/mysql-server/pull/11#issuecomment-2223427044).

This PR also includes the three mtr tests below.  The first two are for testing this new feature, and the last one, for adding a missing test on an existing feature (`log_slow_extra`).  The third test is inspired from the second, and even if this test is not directly related to this work, adding it looked like the right thing to do (and it was easy).
1. sys_vars.log_slow_extra_db_basic
2. sys_vars.log_slow_extra_db_func
3. sys_vars.log_slow_extra_func

There is a limit to this implementation, inherited from [Bug#115526: 	Invalid multi-line "use" in slow query log file with multi-line schema](https://bugs.mysql.com/bug.php?id=115526).  When logging a slow query in a multi-line schema, the `Db` field is on two lines (see example in [1st PR comment](https://github.com/jfg956/mysql-server/pull/11#issuecomment-2223427044)).  It could be escaped, but depending on how the existing bug will be fixed, this might need a rework.  So I am leaving this to be addressed at the same time as Bug#115526.  Also, IMHO, someone using a multi-line schema is looking for trouble, so  ¯\_(ツ)_/¯.

While doing this work, I "played with fire" and tried improving the implementation of the function `File_query_log::write_slow`.  This led to four improvements, which I isolated in four different commits in the Work Branch.  I will let Oracle decide if these should be included or reverted (I can adapt the PR if they ask me to).
- [Remove `buff_len` for `administrator command`](https://github.com/jfg956/mysql-server/pull/8/commits/cc3cbb3a85e2bd5dea97279c9c9782665ef92b8f)
- [With `Db`, make `Id` format consistent with `Thread_id`](https://github.com/jfg956/mysql-server/pull/8/commits/4899363462a638e5b3ded4f40de5cd50e45ff0d4) (already mentioned above)
- [Inline the declaration of `buff_len`](https://github.com/jfg956/mysql-server/pull/8/commits/a36225c5fb806b695ab3e19c4286158e21807ac8)
- [Making usage of `end` clearer with better assignments](https://github.com/jfg956/mysql-server/pull/8/commits/8d44f3090d86ebf3f5acb35143994c5e6e6231b5)

More JFG development notes:
- Work branch: https://github.com/jfg956/mysql-server/tree/mysql-8.4.0_bug106645
- Brain dump: https://github.com/jfg956/mysql-server/blob/mysql-8.4.0_bug106645/jfg_brain_dump.md
- RFC Fake PR: https://github.com/jfg956/mysql-server/pull/9