### PR TITLE
Contrib Fake PR: Testing Patch for Bug#115988 - Too Much Disk Read on Startup, penalizing deployments with many tables (1M+)

### DIFF
--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -23367,6 +23367,24 @@ static MYSQL_SYSVAR_STR(directories, srv_innodb_directories,
                         "'innodb-data-home-dir;innodb-undo-directory;datadir'",
                         nullptr, nullptr, nullptr);
 
+/* TODO: remove once testing done. */
+static MYSQL_SYSVAR_BOOL(
+    tablespace_startup_testing_fadvise, srv_tablespace_startup_testing_fadvise,
+    PLUGIN_VAR_OPCMDARG | PLUGIN_VAR_READONLY | PLUGIN_VAR_NOPERSIST,
+    "For startup fadvise tests, will be removed eventually",
+    nullptr, /* check */
+    nullptr, /* update */
+    false /* def */);
+
+/* TODO: remove once testing done. */
+static MYSQL_SYSVAR_BOOL(
+    tablespace_startup_testing_light, srv_tablespace_startup_testing_light,
+    PLUGIN_VAR_OPCMDARG | PLUGIN_VAR_READONLY | PLUGIN_VAR_NOPERSIST,
+    "For startup light tests, will be removed eventually",
+    nullptr, /* check */
+    nullptr, /* update */
+    false /* def */);
+
 #ifdef UNIV_DEBUG
 /** Use this variable innodb_interpreter to execute debug code within InnoDB.
 The output is stored in the innodb_interpreter_output variable. */
@@ -23525,6 +23543,8 @@ static SYS_VAR *innobase_system_variables[] = {
     MYSQL_SYSVAR(sort_buffer_size),
     MYSQL_SYSVAR(online_alter_log_max_size),
     MYSQL_SYSVAR(directories),
+    MYSQL_SYSVAR(tablespace_startup_testing_fadvise),
+    MYSQL_SYSVAR(tablespace_startup_testing_light),
     MYSQL_SYSVAR(sync_spin_loops),
     MYSQL_SYSVAR(spin_wait_delay),
     MYSQL_SYSVAR(spin_wait_pause_multiplier),

--- a/storage/innobase/include/srv0srv.h
+++ b/storage/innobase/include/srv0srv.h
@@ -400,6 +400,12 @@ extern bool srv_numa_interleave;
 deliminated by ';', i.e the FIL_PATH_SEPARATOR. */
 extern char *srv_innodb_directories;
 
+/* TODO: remove once testing done. */
+/* Documented in storage/innobase/handler/ha_innodb.cc. */
+/* It looks pointless to duplicate comments, if needed, feel free to do it when merging. */
+extern bool srv_tablespace_startup_testing_fadvise;
+extern bool srv_tablespace_startup_testing_light;
+
 /** Server undo tablespaces directory, can be absolute path. */
 extern char *srv_undo_dir;
 

--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -146,6 +146,12 @@ char *srv_doublewrite_dir = nullptr;
 deliminated by ';', i.e the FIL_PATH_SEPARATOR. */
 char *srv_innodb_directories = nullptr;
 
+/* TODO: remove once testing done. */
+/* Documented in storage/innobase/handler/ha_innodb.cc. */
+/* It looks pointless to duplicate comments, if needed, feel free to fo it when merging. */
+bool srv_tablespace_startup_testing_fadvise;
+bool srv_tablespace_startup_testing_light;
+
 /** Number of threads spawned for initializing rollback segments
 in parallel */
 uint32_t srv_rseg_init_threads = 1;


### PR DESCRIPTION
This PR contains a testing patch for reducing the amount of data read from disk during MySQL startup.  When enabling the testing flags (`innodb_tablespace_startup_testing_fadvise` and `innodb_tablespace_startup_testing_light`, disabled by default), the amount of data read per table on startup is divided by 8 (32 kb to 4 kb), which reduces MySQL startup time from 2:39 to 1:09 (1 minute 9 seconds).

This is a "Contrib Fake PR". It is there so people can comment on this work in case it needs adjustments. This has be contributed on 2024-09-03 as a patch file in [Bug#115988](https://bugs.mysql.com/bug.php?id=115988). More about this in a previous RFC blog post, section [Fake PRs and my Way of Working on MySQL Contributions](https://jfg-mysql.blogspot.com/2024/06/rfc-database-schema-in-slow-query-log-file.html#my_way_of_working_on_mysql_contributions).

This PR merges on 9.0.1, and the corresponding patch file applies to 8.4.2 and 8.0.39.  Because this PR significantly improves MySQL startup, I think it should be back ported to 8.0 and 8.4, and if it is considered a "breaking change", with feature flags / global variables to enable the optimizations, disabled by default.

The analysis of the problems addressed by this PR can be found in [Bug#115988: Too Much Disk Read on Startup, penalizing deployments with many tables (1M+)](https://bugs.mysql.com/bug.php?id=115988).

This PR introduces two testing flags / global variables, disabled by default: `innodb_tablespace_startup_testing_fadvise` and `innodb_tablespace_startup_testing_light`.  They allow enabling the optimizations introduced by this PR.  When merging in 9.0, I assumed it did not make sense to keep these, hence "testing" naming and limited documentation.  If it is decided they are needed, they should be renamed and documented adequately, which I can do if asked by Oracle.

While doing this work, I "played with fire" and refactored a few things.  They are identified as "I / JFG had a visceral reaction ..." as comments in the code.  These and other comments are in the code for the clarity of the PR, they should be removed / adjusted when merging.

And one last thing: the "light" optimization will probably not work on filesystems that have a 16-kilobyte block size (like a deployment on zfs).  This means that when avoiding the overhead of the double write buffer, one will have to pay an overhead on startup.  As usual, every optimization has a tradeoff ¯\_(ツ)_/¯.