### PR TITLE
Contrib Fake PR : Bug#116716 - Allow Setting Nb Thread for Tablespace Duplicate Check (startup).

### DIFF
--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -11343,8 +11343,11 @@ dberr_t Tablespace_dirs::scan() {
   Space_id_set unique;
   Space_id_set duplicates;
 
-  /* Get the number of additional threads needed to scan the files. */
-  size_t n_threads = fil_get_scan_threads(ibd_files.size());
+  /* I removed a comment that was redundant, feel free to add it back if you think it added value.
+   * I left this comment for clarity of the patch, it can be removed when merging. */
+  size_t n_threads = (srv_tablespace_duplicate_check_threads == -1)
+                        ? fil_get_scan_threads(ibd_files.size())
+                        : srv_tablespace_duplicate_check_threads;
 
   if (n_threads > 0) {
     ib::info(ER_IB_MSG_382)

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -23439,6 +23439,29 @@ static MYSQL_SYSVAR_STR(directories, srv_innodb_directories,
                         "'innodb-data-home-dir;innodb-undo-directory;datadir'",
                         nullptr, nullptr, nullptr);
 
+/* there is no point in changing this during runtime, thus readonly */
+/* above copied from buffer_pool_load_at_startup */
+/* I / JFG thinks above predates SET PERSIST...
+ * it might make sense to change the value for the next startup. */
+/* TODO: explore allowing to change this with SET PERSIST (but not SET GLOBAL). */
+static MYSQL_SYSVAR_INT(
+    tablespace_duplicate_check_threads, srv_tablespace_duplicate_check_threads,
+    PLUGIN_VAR_OPCMDARG | PLUGIN_VAR_READONLY | PLUGIN_VAR_NOPERSIST,
+    "Number of threads for tablespace duplicate check at startup: "
+    "-1 for auto-compute, 0 for scaning in main thread, 1 in one sub-thread, "
+    "n in sub-threads with spilling in main thread",
+    nullptr, /* check */
+    nullptr, /* update */
+    -1, /* def */
+    -1, /* min */
+    512, /* max, there might be edge-cases for more than 512 threads, but enough for now.
+          * Note that we need 256 threads to leverage 256k iops with 1 milisecond IO latency,
+          *   that AWS io2 EBS volumes can have up to 256k iops with latencies between 0.3 and 0.5 ms,
+          *   so 512 threads is not such an unrealistic max value (maybe this should even be 2048). */
+    0 /* blk, unclear what this is, doc (link below) not helpful, copied from others */);
+/* doc link for blk above:
+ * https://dev.mysql.com/doc/extending-mysql/8.0/en/plugin-status-system-variables.html */
+
 #ifdef UNIV_DEBUG
 /** Use this variable innodb_interpreter to execute debug code within InnoDB.
 The output is stored in the innodb_interpreter_output variable. */
@@ -23597,6 +23620,7 @@ static SYS_VAR *innobase_system_variables[] = {
     MYSQL_SYSVAR(sort_buffer_size),
     MYSQL_SYSVAR(online_alter_log_max_size),
     MYSQL_SYSVAR(directories),
+    MYSQL_SYSVAR(tablespace_duplicate_check_threads),
     MYSQL_SYSVAR(sync_spin_loops),
     MYSQL_SYSVAR(spin_wait_delay),
     MYSQL_SYSVAR(spin_wait_pause_multiplier),

--- a/storage/innobase/include/srv0srv.h
+++ b/storage/innobase/include/srv0srv.h
@@ -400,6 +400,10 @@ extern bool srv_numa_interleave;
 deliminated by ';', i.e the FIL_PATH_SEPARATOR. */
 extern char *srv_innodb_directories;
 
+/* Documented in storage/innobase/handler/ha_innodb.cc. */
+/* It looks pointless to duplicate comments, if needed, feel free to do it when merging. */
+extern int srv_tablespace_duplicate_check_threads;
+
 /** Server undo tablespaces directory, can be absolute path. */
 extern char *srv_undo_dir;
 

--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -146,6 +146,10 @@ char *srv_doublewrite_dir = nullptr;
 deliminated by ';', i.e the FIL_PATH_SEPARATOR. */
 char *srv_innodb_directories = nullptr;
 
+/* Documented in storage/innobase/handler/ha_innodb.cc. */
+/* It looks pointless to duplicate comments, if needed, feel free to fo it when merging. */
+int srv_tablespace_duplicate_check_threads;
+
 /** Number of threads spawned for initializing rollback segments
 in parallel */
 uint32_t srv_rseg_init_threads = 1;


### PR DESCRIPTION
This PR allows setting the number of threads for InnoDB Tablespace Duplicate Check, implementing the feature request [Bug #116716 : Allow Setting Nb Thread for Tablespace Duplicate Check (startup)](https://bugs.mysql.com/bug.php?id=116716).

This is a "Contrib Fake PR". It is there so people can comment on this work in case it needs adjustments. This has been contributed on 2024-12-03 as a patch file in [Bug #116716](https://bugs.mysql.com/bug.php?id=116716). More about Fake PR in the RFC blog post, section [Fake PRs and my Way of Working on MySQL Contributions](https://jfg-mysql.blogspot.com/2024/06/rfc-database-schema-in-slow-query-log-file.html#my_way_of_working_on_mysql_contributions).

This PR merges on 9.1.0, and the patch file also applies on 8.4.3 and 8.0.40.

For allowing setting the number of threads for InnoDB Tablespace Duplicate Check, this PR introduces a new global variable : innodb_tablespace_duplicate_check_threads. The default value is -1, which means the already implemented heuristic is used for setting the number of threads. A value of 0 to MAX VAL overrides the number of threads of the heuristic.

Ideally, in addition to being included in a next Innovation Release, this would be back ported in 8.4 and 8.0. The default value of the global variable introduced by this change is backward compatible with 8.4 and 8.0, so I think this change does not introduce any compatibility problems. And as this change introduces a potential performance improvement making startup faster, I think there is value in back-porting it.

Examples on how this PR is useful was added in [Bug #116716](https://bugs.mysql.com/bug.php?id=116716).

I also blogged about this: [InnoDB Tablespace Duplicate Check Threads](https://jfg-mysql.blogspot.com/2024/11/innodb-tablespace-duplicate-check-threads.html).